### PR TITLE
Refactoriza productos para incluir entidad de imágenes

### DIFF
--- a/src/productos/entities/index.ts
+++ b/src/productos/entities/index.ts
@@ -1,0 +1,2 @@
+export { Producto } from "./producto.entity";
+export { ProductoImagen } from "./producto-imagen.entity";

--- a/src/productos/entities/producto-imagen.entity.ts
+++ b/src/productos/entities/producto-imagen.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  DeleteDateColumn,
+} from 'typeorm';
+import { Producto } from './producto.entity';
+
+@Entity('producto_imagen')
+export class ProductoImagen {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('text')
+  url: string;
+
+  /**
+   * Columna para manejar la fecha de creación del registro.
+   * Se asigna automáticamente al crear una imagen.
+   */
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /**
+   * Columna para manejar el borrado lógico (soft delete).
+   * Almacena la fecha y hora en que se eliminó el registro.
+   */
+  @DeleteDateColumn()
+  deletedAt: Date;
+
+  @ManyToOne(() => Producto, (producto) => producto.images, {
+    onDelete: 'CASCADE',
+  })
+  producto: Producto;
+}

--- a/src/productos/entities/producto.entity.ts
+++ b/src/productos/entities/producto.entity.ts
@@ -1,12 +1,15 @@
 import {
   BeforeInsert,
+  BeforeUpdate,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { CategoriaProducto } from '../enums/categoria-producto.enum';
+import { ProductoImagen } from './';
 
 /**
  * Entidad que representa un producto canjeable en la base de datos.
@@ -84,14 +87,13 @@ export class Producto {
   category: CategoriaProducto;
 
   /**
-   * Arreglo de URLs de las imágenes del producto.
-   * @ejemplo ["https://ejemplo.com/image1.jpg"]
+   * Lista de imágenes asociadas al producto.
+   * Relación uno a muchos con la entidad ProductoImagen.
    */
-  @Column('text', {
-    array: true,
-    default: [],
+  @OneToMany(() => ProductoImagen, (productoImagen) => productoImagen.producto, {
+    cascade: true
   })
-  images: string[];
+  images: ProductoImagen[];
 
   /**
    * Columna para manejar la fecha de creación del registro.
@@ -117,6 +119,14 @@ export class Producto {
       this.slug = this.title;
     }
 
+    this.slug = this.slug
+      .toLowerCase()
+      .replaceAll(' ', '_')
+      .replaceAll("'", '');
+  }
+
+  @BeforeUpdate()
+  checkSlugUpdate() {
     this.slug = this.slug
       .toLowerCase()
       .replaceAll(' ', '_')

--- a/src/productos/productos.module.ts
+++ b/src/productos/productos.module.ts
@@ -2,13 +2,13 @@ import { Module } from '@nestjs/common';
 import { ProductosService } from './productos.service';
 import { ProductosController } from './productos.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Producto } from './entities/producto.entity';
+import { Producto, ProductoImagen} from './entities';
 
 @Module({
   controllers: [ProductosController],
   providers: [ProductosService],
   imports: [
-    TypeOrmModule.forFeature([Producto])
+    TypeOrmModule.forFeature([Producto, ProductoImagen])
   ],
 })
 export class ProductosModule {}


### PR DESCRIPTION
* Se introduce una nueva entidad `ProductoImagen` para manejar las imágenes de los productos, estableciendo una relación uno-a-muchos con la entidad `Producto`. Esto normaliza la base de datos y permite una gestión más robusta de las imágenes.
* Se modifica el `ProductosModule` para importar y registrar la nueva entidad `ProductoImagen`, haciéndola disponible a través de TypeORM en el módulo.
* Se actualiza el `ProductosService` para manejar la creación de productos con sus imágenes asociadas. El método `create` ahora transforma el arreglo de URLs de imágenes del DTO en instancias de la entidad `ProductoImagen`.
* Se mejoran los métodos `findAll`, `findOne` y `findOneWithDeleted` para que realicen un `JOIN` con la tabla de imágenes, asegurando que las imágenes se incluyan en las respuestas de consulta.
* Se añade un hook `@BeforeUpdate` en la entidad `Producto` para regenerar el `slug` automáticamente cada vez que se actualiza el producto, manteniendo la consistencia de los datos.