### PR TITLE
Agrega módulo de puntos y refactoriza limpieza de carrito

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { CarritoModule } from './carrito/carrito.module';
 import { OrdenesModule } from './ordenes/ordenes.module';
 import { ConfiguracionModule } from './configuracion/configuracion.module';
+import { PuntosModule } from './puntos/puntos.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { ConfiguracionModule } from './configuracion/configuracion.module';
     OrdenesModule,
     CarritoModule,
     ConfiguracionModule,
+    PuntosModule,
   ],
   controllers: [],
   providers: [],

--- a/src/puntos/dto/ajustar-puntos.dto.ts
+++ b/src/puntos/dto/ajustar-puntos.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsPositive, IsString, IsUUID } from 'class-validator';
+
+export class AjustarPuntosDto {
+  @ApiProperty({ example: 100, minimum: 1, description: 'Cantidad de puntos a aplicar' })
+  @IsInt()
+  @IsPositive()
+  cantidad: number;
+
+  @ApiPropertyOptional({ example: 'Bonificación por campaña' })
+  @IsString()
+  @IsOptional()
+  concepto?: string;
+
+  @ApiPropertyOptional({ description: 'Referencia a orden asociada', example: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' })
+  @IsUUID()
+  @IsOptional()
+  ordenId?: string;
+}
+

--- a/src/puntos/puntos.controller.ts
+++ b/src/puntos/puntos.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Param, ParseUUIDPipe, Post, Body, Query } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { PuntosService } from './puntos.service';
+import { AjustarPuntosDto } from './dto/ajustar-puntos.dto';
+
+@ApiTags('Puntos')
+@Controller('puntos')
+export class PuntosController {
+  constructor(private readonly puntosService: PuntosService) {}
+
+  @Get(':userId')
+  @ApiParam({ name: 'userId', description: 'UUID del usuario' })
+  @ApiOperation({ summary: 'Consultar saldo de puntos' })
+  @ApiOkResponse({ description: 'Saldo actual', schema: { properties: { userId: { type: 'string' }, saldo: { type: 'number' } } } })
+  getSaldo(@Param('userId', ParseUUIDPipe) userId: string) {
+    return this.puntosService.getSaldo(userId);
+  }
+
+  @Get(':userId/movimientos')
+  @ApiParam({ name: 'userId', description: 'UUID del usuario' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiOperation({ summary: 'Listar movimientos de puntos' })
+  getMovimientos(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('limit') limit?: number,
+    @Query('offset') offset?: number,
+  ) {
+    return this.puntosService.getMovimientos(userId, Number(limit ?? 10), Number(offset ?? 0));
+  }
+
+  @Post(':userId/credit')
+  @ApiParam({ name: 'userId', description: 'UUID del usuario' })
+  @ApiOperation({ summary: 'Acreditar puntos al usuario' })
+  credit(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Body() dto: AjustarPuntosDto,
+  ) {
+    return this.puntosService.credit(userId, dto.cantidad, dto.concepto, dto.ordenId);
+  }
+
+  @Post(':userId/debit')
+  @ApiParam({ name: 'userId', description: 'UUID del usuario' })
+  @ApiOperation({ summary: 'Debitar puntos del usuario' })
+  debit(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Body() dto: AjustarPuntosDto,
+  ) {
+    return this.puntosService.debit(userId, dto.cantidad, dto.concepto, dto.ordenId);
+  }
+}
+

--- a/src/puntos/puntos.module.ts
+++ b/src/puntos/puntos.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PuntosController } from './puntos.controller';
+import { PuntosService } from './puntos.service';
+import { SaldoPuntos } from './entities/saldo-puntos.entity';
+import { MovimientoPuntos } from './entities/movimiento-puntos.entity';
+
+@Module({
+  controllers: [PuntosController],
+  providers: [PuntosService],
+  imports: [TypeOrmModule.forFeature([SaldoPuntos, MovimientoPuntos])],
+  exports: [TypeOrmModule, PuntosService],
+})
+export class PuntosModule {}
+

--- a/src/puntos/puntos.service.ts
+++ b/src/puntos/puntos.service.ts
@@ -1,0 +1,96 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, MoreThanOrEqual, Repository } from 'typeorm';
+import { SaldoPuntos } from './entities/saldo-puntos.entity';
+import { MovimientoPuntos } from './entities/movimiento-puntos.entity';
+
+@Injectable()
+export class PuntosService {
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(SaldoPuntos) private readonly saldoRepo: Repository<SaldoPuntos>,
+    @InjectRepository(MovimientoPuntos) private readonly movRepo: Repository<MovimientoPuntos>,
+  ) {}
+
+  async getSaldo(userId: string) {
+    const saldo = await this.saldoRepo.findOne({ where: { userId } });
+    return { userId, saldo: saldo?.saldo ?? 0 };
+  }
+
+  async getMovimientos(userId: string, limit = 10, offset = 0) {
+    return this.movRepo.find({ where: { userId }, order: { createdAt: 'DESC' }, take: limit, skip: offset });
+  }
+
+  async credit(userId: string, cantidad: number, concepto?: string, ordenId?: string) {
+    if (!Number.isInteger(cantidad) || cantidad <= 0) {
+      throw new BadRequestException('La cantidad debe ser un entero positivo');
+    }
+
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+    try {
+      await qr.manager
+        .createQueryBuilder()
+        .insert()
+        .into(SaldoPuntos)
+        .values({ userId, saldo: 0 })
+        .orIgnore()
+        .execute();
+
+      await qr.manager.increment(SaldoPuntos, { userId }, 'saldo', cantidad);
+
+      const mov = qr.manager.create(MovimientoPuntos, { userId, tipo: 'credito', cantidad, ordenId: ordenId ?? null, concepto });
+      await qr.manager.save(mov);
+
+      await qr.commitTransaction();
+      const nuevo = await this.saldoRepo.findOne({ where: { userId } });
+      return { userId, saldo: nuevo?.saldo ?? 0 };
+    } catch (e) {
+      await qr.rollbackTransaction();
+      throw e;
+    } finally {
+      await qr.release();
+    }
+  }
+
+  async debit(userId: string, cantidad: number, concepto?: string, ordenId?: string) {
+    if (!Number.isInteger(cantidad) || cantidad <= 0) {
+      throw new BadRequestException('La cantidad debe ser un entero positivo');
+    }
+
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+    try {
+      await qr.manager
+        .createQueryBuilder()
+        .insert()
+        .into(SaldoPuntos)
+        .values({ userId, saldo: 0 })
+        .orIgnore()
+        .execute();
+
+      const res = await qr.manager.decrement(
+        SaldoPuntos,
+        { userId, saldo: MoreThanOrEqual(cantidad) },
+        'saldo',
+        cantidad,
+      );
+      if (!res.affected) throw new BadRequestException('Saldo de puntos insuficiente');
+
+      const mov = qr.manager.create(MovimientoPuntos, { userId, tipo: 'debito', cantidad, ordenId: ordenId ?? null, concepto });
+      await qr.manager.save(mov);
+
+      await qr.commitTransaction();
+      const nuevo = await this.saldoRepo.findOne({ where: { userId } });
+      return { userId, saldo: nuevo?.saldo ?? 0 };
+    } catch (e) {
+      await qr.rollbackTransaction();
+      throw e;
+    } finally {
+      await qr.release();
+    }
+  }
+}
+


### PR DESCRIPTION
# Agrega módulo de puntos y refactoriza limpieza de carrito
* Se integra `PuntosModule` al módulo principal de la aplicación para gestionar el sistema de puntos.
* Se refactoriza la lógica de limpieza del carrito en `OrdenesService`.
* Se elimina directamente la entidad `Carrito` en lugar de sus ítems, aprovechando la configuración `onDelete: CASCADE` para simplificar el código.