### PR TITLE
Agrega endpoints protegidos para usuarios y órdenes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,9 @@
 services:
   api:
     build: .
-    container_name: davivienda-fan-shop-api/24bytes
+    container_name: davivienda-fan-shop-api
+    # Optionally tag the built image to reuse/push
+    # image: 24bytes/davivienda-fan-shop-api:1.0.1
     restart: always
     ports:
       - '${API_PORT_DOCKER:-3000}:3000'

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, Get, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -7,6 +7,7 @@ import { ApiBody, ApiCreatedResponse, ApiExtraModels, ApiOkResponse, ApiOperatio
 import { StandardResponseDto } from 'src/common/dtos/standard-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
+import { AdminGuard } from './guards/admin.guard';
 
 /**
  * Controlador de autenticación: registro y login.
@@ -61,5 +62,30 @@ export class AuthController {
     return await this.authService.login(loginDto);
   }
  
+  /**
+   * Lista todos los usuarios activos (solo administradores).
+   */
+  @Get('users')
+  @UseGuards(AdminGuard)
+  @ApiOperation({ summary: 'Listar usuarios activos (solo admin)' })
+  @ApiOkResponse({
+    description: 'Listado de usuarios activos',
+    schema: {
+      allOf: [
+        { $ref: getSchemaPath(StandardResponseDto) },
+        {
+          properties: {
+            data: {
+              type: 'array',
+              items: { $ref: getSchemaPath(UserResponseDto) },
+            },
+          },
+        },
+      ],
+    },
+  })
+  async listUsers() {
+    return await this.authService.listActiveUsers();
+  }
   
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,13 +6,15 @@ import { User } from './entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { FirstUserSeeder } from './providers/first-user.seeder';
+import { AdminGuard } from './guards/admin.guard';
+import { JwtGuard } from './guards/jwt.guard';
 
 /**
  * Módulo de autenticación: controladores, servicios y configuración JWT.
  */
 @Module({
   controllers: [AuthController],
-  providers: [AuthService, FirstUserSeeder],
+  providers: [AuthService, FirstUserSeeder, AdminGuard, JwtGuard],
   imports: [
         // Acceso a variables de entorno
         ConfigModule,
@@ -28,6 +30,6 @@ import { FirstUserSeeder } from './providers/first-user.seeder';
         // Repositorio de la entidad User
         TypeOrmModule.forFeature([User]),
   ],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, JwtModule, AdminGuard, JwtGuard],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -93,6 +93,11 @@ export class AuthService {
     return rest;
   }
 
+  async listActiveUsers() {
+    const users = await this.usersRepository.find({ where: { isActive: true } });
+    return users.map((u) => this.sanitize(u));
+  }
+
   /**
    * Valida credenciales y emite un JWT.
    */

--- a/src/auth/guards/admin.guard.ts
+++ b/src/auth/guards/admin.guard.ts
@@ -1,0 +1,34 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { RolesUsuario } from '../enum/roles-usuario.enum';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const auth = (req.headers?.authorization ?? '') as string;
+    const token = this.extractBearer(auth);
+    if (!token) throw new UnauthorizedException('Token no proporcionado');
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      if (!payload || payload.role !== RolesUsuario.ADMIN) {
+        throw new ForbiddenException('Requiere rol administrador');
+      }
+      req.user = payload;
+      return true;
+    } catch (e) {
+      // If it's an Unauthorized or Forbidden, rethrow; otherwise standardize
+      if (e instanceof UnauthorizedException || e instanceof ForbiddenException) throw e;
+      throw new UnauthorizedException('Token inválido o expirado');
+    }
+  }
+
+  private extractBearer(header: string): string | null {
+    const parts = header.split(' ');
+    if (parts.length === 2 && /^Bearer$/i.test(parts[0])) return parts[1];
+    return null;
+  }
+}
+

--- a/src/auth/guards/jwt.guard.ts
+++ b/src/auth/guards/jwt.guard.ts
@@ -1,0 +1,28 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class JwtGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const auth = (req.headers?.authorization ?? '') as string;
+    const token = this.extractBearer(auth);
+    if (!token) throw new UnauthorizedException('Token no proporcionado');
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      req.user = payload;
+      return true;
+    } catch (_) {
+      throw new UnauthorizedException('Token inválido o expirado');
+    }
+  }
+
+  private extractBearer(header: string): string | null {
+    const parts = header.split(' ');
+    if (parts.length === 2 && /^Bearer$/i.test(parts[0])) return parts[1];
+    return null;
+  }
+}
+

--- a/src/ordenes/ordenes.controller.ts
+++ b/src/ordenes/ordenes.controller.ts
@@ -1,7 +1,8 @@
-﻿import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+﻿import { Body, Controller, Get, Param, Post, UseGuards, Req } from '@nestjs/common';
 import { OrdenesService } from './ordenes.service';
 import { ModoPago } from './entities/orden.entity';
-import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { JwtGuard } from 'src/auth/guards/jwt.guard';
 
 /**
  * Endpoints para gestión de órdenes y checkout.
@@ -16,6 +17,16 @@ export class OrdenesController {
   @ApiParam({ name: 'userId', description: 'UUID del usuario' })
   @ApiOperation({ summary: 'Listar órdenes del usuario' })
   findByUser(@Param('userId') userId: string) {
+    return this.ordenesService.findByUser(userId);
+  }
+
+  /** Listar órdenes del usuario autenticado (token). */
+  @Get('mis-ordenes')
+  @UseGuards(JwtGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Listar mis órdenes (requiere token)' })
+  findMyOrders(@Req() req: any) {
+    const userId = req.user?.sub as string;
     return this.ordenesService.findByUser(userId);
   }
 

--- a/src/ordenes/ordenes.module.ts
+++ b/src/ordenes/ordenes.module.ts
@@ -10,12 +10,13 @@ import { Producto } from 'src/productos/entities/producto.entity';
 import { SaldoPuntos } from 'src/puntos/entities/saldo-puntos.entity';
 import { MovimientoPuntos } from 'src/puntos/entities/movimiento-puntos.entity';
 import { ConfiguracionModule } from 'src/configuracion/configuracion.module';
+import { AuthModule } from 'src/auth/auth.module';
 
 /**
  * Módulo de órdenes y checkout.
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([Orden, OrdenItem, Carrito, CarritoItem, Producto, SaldoPuntos, MovimientoPuntos]), ConfiguracionModule],
+  imports: [TypeOrmModule.forFeature([Orden, OrdenItem, Carrito, CarritoItem, Producto, SaldoPuntos, MovimientoPuntos]), ConfiguracionModule, AuthModule],
   providers: [OrdenesService],
   controllers: [OrdenesController],
   exports: [TypeOrmModule, OrdenesService],


### PR DESCRIPTION
# Agrega endpoints protegidos para usuarios y órdenes
* Se crea un endpoint `GET /auth/users` protegido por un `AdminGuard` para listar usuarios activos.
* Se añade un endpoint `GET /ordenes/mis-ordenes` para que usuarios autenticados consulten sus propias órdenes.
* Se exportan los guards (`AdminGuard`, `JwtGuard`) desde `AuthModule` para su uso en otros módulos.
* Se ajusta el nombre del contenedor en `docker-compose.yaml` para mayor simplicidad.